### PR TITLE
chore: bump version of gateway api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <gravitee-bom.version>1.0</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.31.0-SNAPSHOT</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.4.0</gravitee-policy-api.version>
         <gravitee-common.version>1.14.0</gravitee-common.version>
 


### PR DESCRIPTION
Description
--
Remove snapshot versions to make semantic release happy
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.9.0-chore-bump-gateway-api`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/1.9.0-chore-bump-gateway-api/gravitee-policy-ipfiltering-1.9.0-chore-bump-gateway-api.zip)
  <!-- Version placeholder end -->
