### PR TITLE
add the IPFILTERING_FORBIDDEN response template

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -83,3 +83,20 @@ You can configure the policy with the following options:
 | Your IP (0.0.0.0) or one of the proxies your request passed through is not allowed to reach this resource
 
 |===
+
+=== Default response override
+
+You can use the response template feature to override the default responses provided by the policy. These templates must be defined at the API level (see the API Console *Response Templates*
+option in the API *Proxy* menu).
+
+=== Error keys
+
+The error keys sent by this policy are as follows:
+
+[cols="2*", options="header"]
+|===
+^|Key
+^|Parameters
+
+.^|IPFILTERING_FORBIDDEN
+^.^|address

--- a/pom.xml
+++ b/pom.xml
@@ -39,13 +39,13 @@
     <properties>
         <gravitee-bom.version>1.0</gravitee-bom.version>
         <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
-        <gravitee-policy-api.version>1.4.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.14.0</gravitee-common.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
+        <gravitee-common.version>1.15.5</gravitee-common.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
+        <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
         <commons-net.version>3.6</commons-net.version>
         <commons-validator.version>1.7</commons-validator.version>
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>

--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
@@ -19,6 +19,7 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.common.util.Maps;
 import io.gravitee.gateway.api.ExecutionContext;
 import io.gravitee.gateway.api.Request;
 import io.gravitee.gateway.api.http.HttpHeaderNames;
@@ -48,6 +49,8 @@ import org.slf4j.LoggerFactory;
 public class IPFilteringPolicy {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IPFilteringPolicy.class);
+
+    private static final String IPFILTERING_FORBIDDEN = "IPFILTERING_FORBIDDEN";
 
     /**
      * The associated configuration to this IPFiltering Policy
@@ -170,8 +173,10 @@ public class IPFilteringPolicy {
     private void fail(PolicyChain policyChain, String remoteAddress) {
         policyChain.failWith(
             PolicyResult.failure(
+                IPFILTERING_FORBIDDEN,
                 HttpStatusCode.FORBIDDEN_403,
-                "Your IP (" + remoteAddress + ") or some proxies whereby your request pass through are not allowed to reach this resource."
+                "Your IP (" + remoteAddress + ") or some proxies whereby your request pass through are not allowed to reach this resource.",
+                Maps.<String, Object>builder().put("address", remoteAddress).build()
             )
         );
     }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/6091

**Description**

add the **IPFILTERING_FORBIDDEN** response template to override the default responses provided by the ipfiltering policy

**Additional context**

I've tested the changes with the graviteeio/apim-gateway:3.15.3 docker image
