### PR TITLE
Apim 2140 ipfiltering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@2.0
+    gravitee: gravitee-io/gravitee@4.1.0
+
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
@@ -22,7 +23,7 @@ workflows:
     setup_release:
         when:
             matches:
-                pattern: "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+                pattern: "/^[0-9]+\\.[0-9]+\\.[0-9]+(-(alpha|beta|rc)\\.[0-9]+)?$/"
                 value: << pipeline.git.tag >>
         jobs:
             - gravitee/setup_plugin-release-config:
@@ -32,4 +33,4 @@ workflows:
                               - /.*/
                       tags:
                           only:
-                              - /^[0-9]+\.[0-9]+\.[0-9]+$/
+                              - /^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$/

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,14 +1,22 @@
 {
   "extends": [
-    "config:base",
-    "schedule:earlyMondays"
+    "config:base"
   ],
-  "prConcurrentLimit": 3,
   "rebaseWhen": "conflicted",
   "packageRules": [
     {
       "matchDatasources": ["orb"],
-      "rangeStrategy": "replace"
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "ci"
+    },
+    {
+      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "semanticCommitType": "chore"
     }
   ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -33,11 +33,11 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>20.0</version>
+        <version>21.0.1</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>1.0</gravitee-bom.version>
+        <gravitee-bom.version>5.0.0</gravitee-bom.version>
         <gravitee-gateway-api.version>1.31.0</gravitee-gateway-api.version>
         <gravitee-policy-api.version>1.4.0</gravitee-policy-api.version>
         <gravitee-common.version>1.14.0</gravitee-common.version>

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,3 +6,4 @@ class=io.gravitee.policy.ipfiltering.IPFilteringPolicy
 type=policy
 category=security
 icon=ip-filtering.svg
+proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,6 +1,7 @@
 {
-  "type" : "object",
-  "id" : "urn:jsonschema:io:gravitee:policy:IPFilteringPolicyConfiguration",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
   "properties" : {
     "matchAllFromXForwardedFor" : {
       "title" : "Use X-Forwarded-For header",


### PR DESCRIPTION
**Issue**

APIM-2140

**Description**

- update renovate
- update cci & gravitee-parent
- update schema form & add exec phase
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.10.0-apim-2140-ipfiltering-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/1.10.0-apim-2140-ipfiltering-SNAPSHOT/gravitee-policy-ipfiltering-1.10.0-apim-2140-ipfiltering-SNAPSHOT.zip)
  <!-- Version placeholder end -->
