### PR TITLE
Fix this /31 and /32 CIDR block issue

### DIFF
--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
@@ -196,6 +196,9 @@ public class IPFilteringPolicy {
                     }
                     try {
                         SubnetUtils utils = new SubnetUtils(filterIp);
+                        if (configuration.isInclusiveHostCount()) {
+                            utils.setInclusiveHostCount(true);
+                        }
                         return utils.getInfo().isInRange(ip);
                     } catch (IllegalArgumentException iae) {
                         return false;

--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyConfiguration.java
@@ -42,6 +42,8 @@ public class IPFilteringPolicyConfiguration implements PolicyConfiguration {
      */
     private LookupIpVersion lookupIpVersion;
 
+    private boolean isInclusiveHostCount = false;
+
     public boolean isMatchAllFromXForwardedFor() {
         return matchAllFromXForwardedFor;
     }
@@ -72,5 +74,13 @@ public class IPFilteringPolicyConfiguration implements PolicyConfiguration {
 
     public void setLookupIpVersion(LookupIpVersion lookupIpVersion) {
         this.lookupIpVersion = lookupIpVersion;
+    }
+
+    public void setInclusiveHostCount(boolean inclusiveHostCount) {
+        isInclusiveHostCount = inclusiveHostCount;
+    }
+
+    public boolean isInclusiveHostCount() {
+        return isInclusiveHostCount;
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -35,6 +35,11 @@
         "ALL"
       ],
       "default": "ALL"
+    },
+    "isInclusiveHostCount": {
+        "title": "Inclusive Host Count",
+        "description": "If true, include the network and broadcast addresses (useful for CIDR/31 and CIDR/32).",
+        "type": "boolean"
     }
   }
 }

--- a/src/test/java/io/gravitee/policy/IsFilteredTest.java
+++ b/src/test/java/io/gravitee/policy/IsFilteredTest.java
@@ -100,6 +100,17 @@ public class IsFilteredTest {
         }
     }
 
+    @Test
+    public void shouldFilteredCIDR_With_isInclusiveHostCount() {
+        IPFilteringPolicyConfiguration configuration = new IPFilteringPolicyConfiguration();
+        configuration.setInclusiveHostCount(true);
+        IPFilteringPolicy policy = new IPFilteringPolicy(configuration);
+
+        boolean filtered = policy.isFiltered("192.168.1.0", Collections.singletonList("192.168.1.0/31"));
+
+        assertTrue("should filter ", filtered);
+    }
+
     /**
      * TEST CIDR
      */


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/9602
https://gravitee.atlassian.net/browse/APIM-4336

**Description**

One line fix.

Set InclusiveHostCount to true to include the network and broadcast addresses (needed for /31 and /32 CIDR blocks) in the check performed by the method SubnetUtils.SubnetInfo.isInRange()

![image](https://github.com/gravitee-io/gravitee-policy-ipfiltering/assets/4974420/fd77b167-ce97-4579-9a7d-505e95da9ffb)



<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.14.0-fix-InclusiveHostCount-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/1.14.0-fix-InclusiveHostCount-SNAPSHOT/gravitee-policy-ipfiltering-1.14.0-fix-InclusiveHostCount-SNAPSHOT.zip)
  <!-- Version placeholder end -->
