### PR TITLE
feat: add the possibility to configure the IP version when lookup for host

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -66,6 +66,13 @@ At the policy level, you can configure the following options:
 |string list
 |`empty`
 
+|lookupIpVersion
+|No
+|IP version to use to lookup host name. If you're not sure your DNS server can handle multi-question requests (both V4 and V6) specify a version.
+|enum [`IPV4`, `IPV6`, `ALL`]
+|`ALL`
+
+
 |===
 
 [#_gateway]
@@ -95,7 +102,8 @@ policy:
   ],
   "blacklistIps": [
     null
-  ]
+  ],
+  "lookupIpVersion": "IPV4"
 }
 ----
 

--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
@@ -75,23 +75,23 @@ public class IPFilteringPolicy {
                 filteredHosts.forEach(host -> {
                     final Promise<Void> promise = Promise.promise();
                     futures.add(promise.future());
-                    LazyDnsClient
-                        .get(executionContext)
-                        .lookup(
-                            host,
-                            event -> {
-                                if (event.succeeded()) {
-                                    if (executionContext.request().remoteAddress().equals(event.result())) {
-                                        promise.fail("");
-                                    } else {
-                                        promise.complete();
-                                    }
+                    LazyDnsClient.lookup(
+                        executionContext,
+                        configuration.getLookupIpVersion(),
+                        host,
+                        event -> {
+                            if (event.succeeded()) {
+                                if (executionContext.request().remoteAddress().equals(event.result())) {
+                                    promise.fail("");
                                 } else {
-                                    LOGGER.error("Cannot resolve host: '" + host + "'", event.cause());
                                     promise.complete();
                                 }
+                            } else {
+                                LOGGER.error("Cannot resolve host: '" + host + "'", event.cause());
+                                promise.complete();
                             }
-                        );
+                        }
+                    );
                 });
             }
         }
@@ -109,23 +109,23 @@ public class IPFilteringPolicy {
                 filteredHosts.forEach(host -> {
                     final Promise<Void> promise = Promise.promise();
                     futures.add(promise.future());
-                    LazyDnsClient
-                        .get(executionContext)
-                        .lookup(
-                            host,
-                            event -> {
-                                if (event.succeeded()) {
-                                    if (!executionContext.request().remoteAddress().equals(event.result())) {
-                                        promise.fail("");
-                                    } else {
-                                        promise.complete();
-                                    }
+                    LazyDnsClient.lookup(
+                        executionContext,
+                        configuration.getLookupIpVersion(),
+                        host,
+                        event -> {
+                            if (event.succeeded()) {
+                                if (!executionContext.request().remoteAddress().equals(event.result())) {
+                                    promise.fail("");
                                 } else {
-                                    LOGGER.error("Cannot resolve host: '" + host + "'", event.cause());
                                     promise.complete();
                                 }
+                            } else {
+                                LOGGER.error("Cannot resolve host: '" + host + "'", event.cause());
+                                promise.complete();
                             }
-                        );
+                        }
+                    );
                 });
             }
         }

--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyConfiguration.java
@@ -37,6 +37,11 @@ public class IPFilteringPolicyConfiguration implements PolicyConfiguration {
      */
     private List<String> blacklistIps;
 
+    /**
+     * The IP Version supported to make the lookup
+     */
+    private LookupIpVersion lookupIpVersion;
+
     public boolean isMatchAllFromXForwardedFor() {
         return matchAllFromXForwardedFor;
     }
@@ -59,5 +64,13 @@ public class IPFilteringPolicyConfiguration implements PolicyConfiguration {
 
     public void setBlacklistIps(List<String> blacklistIps) {
         this.blacklistIps = blacklistIps == null ? List.of() : blacklistIps.stream().map(String::trim).collect(Collectors.toList());
+    }
+
+    public LookupIpVersion getLookupIpVersion() {
+        return lookupIpVersion == null ? LookupIpVersion.ALL : lookupIpVersion;
+    }
+
+    public void setLookupIpVersion(LookupIpVersion lookupIpVersion) {
+        this.lookupIpVersion = lookupIpVersion;
     }
 }

--- a/src/main/java/io/gravitee/policy/ipfiltering/LookupIpVersion.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/LookupIpVersion.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.policy.ipfiltering;
+
+public enum LookupIpVersion {
+    IPV4,
+    IPV6,
+    ALL,
+}

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -24,6 +24,17 @@
         "type" : "string",
         "minLength": 1
       }
+    },
+    "lookupIpVersion" : {
+      "title" : "Lookup IP version to use (default is ALL)",
+      "description": "If you're not sure your DNS server can handle multi-question requests (both V4 and V6) specify a version",
+      "type" : "string",
+      "enum": [
+        "IPV4",
+        "IPV6",
+        "ALL"
+      ],
+      "default": "ALL"
     }
   }
 }


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-4146

**Description**

We use `DnsClient.lookup()` to retrieve the IP adresses of a domain.
But this DnsClient prepares a datagram with 2 questions/queries:
![image](https://github.com/gravitee-io/gravitee-policy-ipfiltering/assets/13161768/8489cd45-8b4e-49a5-9a89-2f5c4fbc839c)

This kind of requests is supported by Google DNS 8.8.8.8, but not all DNS Servers are able to handle such requests.

To fix that, I introduce a configuration to allow the API Publisher to choose which version IP version to use. With this setting, we can choose to use `lookup4` or `lookup6`, which generate a datagram with only one question/query.

See https://github.com/eclipse-vertx/vert.x/issues/5035#issuecomment-1973039058