### PR TITLE
feat: support custom header for IP address

### DIFF
--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyConfiguration.java
@@ -44,6 +44,10 @@ public class IPFilteringPolicyConfiguration implements PolicyConfiguration {
 
     private boolean isInclusiveHostCount = false;
 
+    private boolean useCustomIPAddress;
+
+    private String customIPAddress;
+
     public boolean isMatchAllFromXForwardedFor() {
         return matchAllFromXForwardedFor;
     }
@@ -82,5 +86,21 @@ public class IPFilteringPolicyConfiguration implements PolicyConfiguration {
 
     public boolean isInclusiveHostCount() {
         return isInclusiveHostCount;
+    }
+
+    public String getCustomIPAddress() {
+        return customIPAddress;
+    }
+
+    public void setCustomIPAddress(String customIPAddress) {
+        this.customIPAddress = customIPAddress;
+    }
+
+    public boolean isUseCustomIPAddress() {
+        return useCustomIPAddress;
+    }
+
+    public void setUseCustomIPAddress(boolean useCustomIPAddress) {
+        this.useCustomIPAddress = useCustomIPAddress;
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -5,7 +5,49 @@
   "properties" : {
     "matchAllFromXForwardedFor" : {
       "title" : "Use X-Forwarded-For header",
-      "type" : "boolean"
+      "type" : "boolean",
+      "x-schema-form": {
+        "hidden": [
+          {
+          "$eq": {
+            "useCustomIPAddress": true
+          }
+          }
+        ]
+      },
+      "gioConfig": {
+        "displayIf": {
+          "$eq": {
+            "value.useCustomIPAddress": false
+          }
+        }
+      }
+    },
+    "useCustomIPAddress": {
+      "title":"Use custom IP address (support EL)",
+      "type": "boolean"
+    },
+    "customIPAddress": {
+      "title": "Custom IP Address (support comma separated list)",
+      "description": "Support EL (ex: {#request.headers['X-Forwarded-For']})",
+      "type": "string",
+      "x-schema-form": {
+        "expression-language": true,
+        "hidden": [
+          {
+            "$eq": {
+              "useCustomIPAddress": false
+            }
+          }
+        ]
+      },
+      "gioConfig": {
+        "displayIf": {
+          "$eq": {
+            "value.useCustomIPAddress": true
+          }
+        }
+      }
     },
     "whitelistIps" : {
       "title" : "IPs Whitelist (CIDR and hosts allowed)",

--- a/src/test/java/io/gravitee/policy/IPFilteringPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/IPFilteringPolicyTest.java
@@ -121,7 +121,7 @@ public class IPFilteringPolicyTest {
     @Test
     public void shouldTestXFF() throws Exception {
         when(mockConfiguration.isMatchAllFromXForwardedFor()).thenReturn(true);
-        when(mockRequest.headers()).thenReturn(HttpHeaders.create());
+        when(mockRequest.headers()).thenReturn(HttpHeaders.create().set(HttpHeaderNames.X_FORWARDED_FOR, "localhost"));
         IPFilteringPolicy policy = new IPFilteringPolicy(mockConfiguration);
 
         policy.onRequest(executionContext, mockPolicychain);


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-5073

**Description**

support custom header for extracting ip address.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.17.0-APIM-5073-feat-support-custom-header-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/1.17.0-APIM-5073-feat-support-custom-header-SNAPSHOT/gravitee-policy-ipfiltering-1.17.0-APIM-5073-feat-support-custom-header-SNAPSHOT.zip)
  <!-- Version placeholder end -->
