### PR TITLE
feat: support comma-separated IPs in wl/bl

### DIFF
--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
@@ -218,6 +218,11 @@ public class IPFilteringPolicy {
         if (givenList == null) {
             return Set.of();
         }
-        return givenList.stream().map(given -> ctx.getTemplateEngine().getValue(given, String.class)).collect(Collectors.toSet());
+        return givenList
+            .stream()
+            .map(given -> ctx.getTemplateEngine().getValue(given, String.class))
+            .map(k -> k != null && !k.isEmpty() ? k.split(",") : new String[] {})
+            .flatMap(Arrays::stream)
+            .collect(Collectors.toSet());
     }
 }

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -51,6 +51,7 @@
     },
     "whitelistIps" : {
       "title" : "IPs Whitelist (CIDR and hosts allowed)",
+      "description": "List of IPs to allow in the request. Each entry may be a comma-separated list.",
       "type" : "array",
       "items" : {
         "title" : "IP / CIDR / Host",
@@ -60,6 +61,7 @@
     },
     "blacklistIps" : {
       "title" : "IPs Blacklist (CIDR and hosts allowed)",
+      "description": "List of IPs to disallow in the request. Each entry may be a comma-separated list.",
       "type" : "array",
       "items" : {
         "title" : "IP / CIDR / Host",


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9007

**Description**

Add support for comma-separated IPs in whitelist and blacklist fields
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.18.0-comma-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/1.18.0-comma-SNAPSHOT/gravitee-policy-ipfiltering-1.18.0-comma-SNAPSHOT.zip)
  <!-- Version placeholder end -->
