### PR TITLE
fix: isInclusiveHostCount boolean getter method

### DIFF
--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
@@ -202,7 +202,7 @@ public class IPFilteringPolicy {
                     }
                     try {
                         SubnetUtils utils = new SubnetUtils(filterIp);
-                        if (configuration.isInclusiveHostCount()) {
+                        if (configuration.getIsInclusiveHostCount()) {
                             utils.setInclusiveHostCount(true);
                         }
                         return utils.getInfo().isInRange(ip);

--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyConfiguration.java
@@ -80,11 +80,11 @@ public class IPFilteringPolicyConfiguration implements PolicyConfiguration {
         this.lookupIpVersion = lookupIpVersion;
     }
 
-    public void setInclusiveHostCount(boolean inclusiveHostCount) {
+    public void setIsInclusiveHostCount(boolean inclusiveHostCount) {
         isInclusiveHostCount = inclusiveHostCount;
     }
 
-    public boolean isInclusiveHostCount() {
+    public boolean getIsInclusiveHostCount() {
         return isInclusiveHostCount;
     }
 

--- a/src/test/java/io/gravitee/policy/IsFilteredTest.java
+++ b/src/test/java/io/gravitee/policy/IsFilteredTest.java
@@ -103,7 +103,7 @@ public class IsFilteredTest {
     @Test
     public void shouldFilteredCIDR_With_isInclusiveHostCount() {
         IPFilteringPolicyConfiguration configuration = new IPFilteringPolicyConfiguration();
-        configuration.setInclusiveHostCount(true);
+        configuration.setIsInclusiveHostCount(true);
         IPFilteringPolicy policy = new IPFilteringPolicy(configuration);
 
         boolean filtered = policy.isFiltered("192.168.1.0", Collections.singletonList("192.168.1.0/31"));


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9076

**Description**

fix getter and setter methods for isInclusiveHostName

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.18.1-APIM-9076-fix-isInclusiveHostCount-getter-method-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/1.18.1-APIM-9076-fix-isInclusiveHostCount-getter-method-SNAPSHOT/gravitee-policy-ipfiltering-1.18.1-APIM-9076-fix-isInclusiveHostCount-getter-method-SNAPSHOT.zip)
  <!-- Version placeholder end -->
