### PR TITLE
fix: resolve 403 error for custom IP

### DIFF
--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
@@ -83,7 +83,9 @@ public class IPFilteringPolicy {
                         host,
                         event -> {
                             if (event.succeeded()) {
-                                if (event.result().contains(executionContext.request().remoteAddress())) {
+                                List<String> resolvedIps = event.result();
+                                boolean matchFound = ips.stream().anyMatch(resolvedIps::contains);
+                                if (matchFound) {
                                     promise.fail("");
                                 } else {
                                     promise.complete();
@@ -119,7 +121,9 @@ public class IPFilteringPolicy {
                         host,
                         event -> {
                             if (event.succeeded()) {
-                                if (!event.result().contains(executionContext.request().remoteAddress())) {
+                                List<String> resolvedIps = event.result();
+                                boolean matchFound = ips.stream().anyMatch(resolvedIps::contains);
+                                if (!matchFound) {
                                     promise.fail("");
                                 } else {
                                     promise.complete();


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-9774

**Description**

fix: resolve 403 error for custom IP for IP Filtering Policy

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.19.1-APIM-9774-fix-customIP-not-resolving-hostname-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/1.19.1-APIM-9774-fix-customIP-not-resolving-hostname-SNAPSHOT/gravitee-policy-ipfiltering-1.19.1-APIM-9774-fix-customIP-not-resolving-hostname-SNAPSHOT.zip)
  <!-- Version placeholder end -->
