### PR TITLE
bump dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ setup: true
 orbs:
     gravitee: gravitee-io/gravitee@4.14.2
 
-
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)
 workflows:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["github>gravitee-io/renovate-config:lib"]
+    "extends": ["github>gravitee-io/renovate-config:lib"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,22 +1,3 @@
 {
-  "extends": [
-    "config:base"
-  ],
-  "rebaseWhen": "conflicted",
-  "packageRules": [
-    {
-      "matchDatasources": ["orb"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "ci"
-    },
-    {
-      "matchDepTypes": ["provided", "test", "build", "import", "parent"],
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true,
-      "automergeType": "branch",
-      "semanticCommitType": "chore"
-    }
-  ]
+  "extends": ["github>gravitee-io/renovate-config:lib"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
         <gravitee-node-api.version>6.8.0</gravitee-node-api.version>
 
-        <gravitee-policy-api.version>1.4.0</gravitee-policy-api.version>
+        <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-common.version>1.28.0</gravitee-common.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
-        <commons-net.version>3.6</commons-net.version>
+        <commons-net.version>3.12.0</commons-net.version>
         <commons-validator.version>1.10.0</commons-validator.version>
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <properties>
         <gravitee-bom.version>8.3.27</gravitee-bom.version>
         <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
-        <gravitee-node-api.version>1.27.9</gravitee-node-api.version>
+        <gravitee-node-api.version>6.8.0</gravitee-node-api.version>
 
         <gravitee-policy-api.version>1.4.0</gravitee-policy-api.version>
         <gravitee-common.version>1.28.0</gravitee-common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <gravitee-node-api.version>6.8.0</gravitee-node-api.version>
 
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>1.28.0</gravitee-common.version>
+        <gravitee-common.version>4.7.0</gravitee-common.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <gravitee-bom.version>8.3.27</gravitee-bom.version>
-        <gravitee-gateway-api.version>1.47.1</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>3.8.1</gravitee-gateway-api.version>
         <gravitee-node-api.version>1.27.9</gravitee-node-api.version>
 
         <gravitee-policy-api.version>1.4.0</gravitee-policy-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>21.0.1</version>
+        <version>22.5.1</version>
     </parent>
 
     <properties>
@@ -47,9 +47,9 @@
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>
 
-        <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <commons-net.version>3.12.0</commons-net.version>
         <commons-validator.version>1.10.0</commons-validator.version>
+
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
 
@@ -201,10 +201,17 @@
             <plugin>
                 <groupId>com.hubspot.maven.plugins</groupId>
                 <artifactId>prettier-maven-plugin</artifactId>
-                <version>0.22</version>
+                <version>${prettier-maven-plugin.version}</version>
                 <configuration>
-                    <nodeVersion>12.13.0</nodeVersion>
-                    <prettierJavaVersion>1.6.1</prettierJavaVersion>
+                    <prettierJavaVersion>${prettier-maven-plugin.prettierJavaVersion}</prettierJavaVersion>
+                    <skip>${skip.validation}</skip>
+                    <inputGlobs>
+                        <inputGlob>src/main/java/**/*.java</inputGlob>
+                        <inputGlob>src/test/java/**/*.java</inputGlob>
+                        <inputGlob>{src,.circle,.github}/**/*.json</inputGlob>
+                        <inputGlob>src/**/*.yaml</inputGlob>
+                        <inputGlob>src/**/*.yml</inputGlob>
+                    </inputGlobs>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 
         <maven-assembly-plugin.version>2.5.5</maven-assembly-plugin.version>
         <commons-net.version>3.6</commons-net.version>
-        <commons-validator.version>1.7</commons-validator.version>
+        <commons-validator.version>1.10.0</commons-validator.version>
         <publish-folder-path>graviteeio-apim/plugins/policies</publish-folder-path>
     </properties>
 

--- a/src/assembly/policy-assembly.xml
+++ b/src/assembly/policy-assembly.xml
@@ -1,12 +1,12 @@
 <!--
 
-    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+    Copyright © 2015 The Gravitee team (http://gravitee.io)
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-            http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/ipfiltering/DnsConfiguration.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/DnsConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyConfiguration.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyConfiguration.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/ipfiltering/LazyDnsClient.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/LazyDnsClient.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/java/io/gravitee/policy/ipfiltering/LookupIpVersion.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/LookupIpVersion.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -1,89 +1,85 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "type": "object",
-  "additionalProperties": false,
-  "properties" : {
-    "matchAllFromXForwardedFor" : {
-      "title" : "Use X-Forwarded-For header",
-      "type" : "boolean",
-      "x-schema-form": {
-        "hidden": [
-          {
-          "$eq": {
-            "useCustomIPAddress": true
-          }
-          }
-        ]
-      },
-      "gioConfig": {
-        "displayIf": {
-          "$eq": {
-            "value.useCustomIPAddress": false
-          }
-        }
-      }
-    },
-    "useCustomIPAddress": {
-      "title":"Use custom IP address (support EL)",
-      "type": "boolean"
-    },
-    "customIPAddress": {
-      "title": "Custom IP Address (support comma separated list)",
-      "description": "Support EL (ex: {#request.headers['X-Forwarded-For']})",
-      "type": "string",
-      "x-schema-form": {
-        "expression-language": true,
-        "hidden": [
-          {
-            "$eq": {
-              "useCustomIPAddress": false
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "matchAllFromXForwardedFor": {
+            "title": "Use X-Forwarded-For header",
+            "type": "boolean",
+            "x-schema-form": {
+                "hidden": [
+                    {
+                        "$eq": {
+                            "useCustomIPAddress": true
+                        }
+                    }
+                ]
+            },
+            "gioConfig": {
+                "displayIf": {
+                    "$eq": {
+                        "value.useCustomIPAddress": false
+                    }
+                }
             }
-          }
-        ]
-      },
-      "gioConfig": {
-        "displayIf": {
-          "$eq": {
-            "value.useCustomIPAddress": true
-          }
+        },
+        "useCustomIPAddress": {
+            "title": "Use custom IP address (support EL)",
+            "type": "boolean"
+        },
+        "customIPAddress": {
+            "title": "Custom IP Address (support comma separated list)",
+            "description": "Support EL (ex: {#request.headers['X-Forwarded-For']})",
+            "type": "string",
+            "x-schema-form": {
+                "expression-language": true,
+                "hidden": [
+                    {
+                        "$eq": {
+                            "useCustomIPAddress": false
+                        }
+                    }
+                ]
+            },
+            "gioConfig": {
+                "displayIf": {
+                    "$eq": {
+                        "value.useCustomIPAddress": true
+                    }
+                }
+            }
+        },
+        "whitelistIps": {
+            "title": "IPs Whitelist (CIDR and hosts allowed)",
+            "description": "List of IPs to allow in the request. Each entry may be a comma-separated list.",
+            "type": "array",
+            "items": {
+                "title": "IP / CIDR / Host",
+                "type": "string",
+                "minLength": 1
+            }
+        },
+        "blacklistIps": {
+            "title": "IPs Blacklist (CIDR and hosts allowed)",
+            "description": "List of IPs to disallow in the request. Each entry may be a comma-separated list.",
+            "type": "array",
+            "items": {
+                "title": "IP / CIDR / Host",
+                "type": "string",
+                "minLength": 1
+            }
+        },
+        "lookupIpVersion": {
+            "title": "Lookup IP version to use (default is ALL)",
+            "description": "If you're not sure your DNS server can handle multi-question requests (both V4 and V6) specify a version",
+            "type": "string",
+            "enum": ["IPV4", "IPV6", "ALL"],
+            "default": "ALL"
+        },
+        "isInclusiveHostCount": {
+            "title": "Inclusive Host Count",
+            "description": "If true, include the network and broadcast addresses (useful for CIDR/31 and CIDR/32).",
+            "type": "boolean"
         }
-      }
-    },
-    "whitelistIps" : {
-      "title" : "IPs Whitelist (CIDR and hosts allowed)",
-      "description": "List of IPs to allow in the request. Each entry may be a comma-separated list.",
-      "type" : "array",
-      "items" : {
-        "title" : "IP / CIDR / Host",
-        "type" : "string",
-        "minLength": 1
-      }
-    },
-    "blacklistIps" : {
-      "title" : "IPs Blacklist (CIDR and hosts allowed)",
-      "description": "List of IPs to disallow in the request. Each entry may be a comma-separated list.",
-      "type" : "array",
-      "items" : {
-        "title" : "IP / CIDR / Host",
-        "type" : "string",
-        "minLength": 1
-      }
-    },
-    "lookupIpVersion" : {
-      "title" : "Lookup IP version to use (default is ALL)",
-      "description": "If you're not sure your DNS server can handle multi-question requests (both V4 and V6) specify a version",
-      "type" : "string",
-      "enum": [
-        "IPV4",
-        "IPV6",
-        "ALL"
-      ],
-      "default": "ALL"
-    },
-    "isInclusiveHostCount": {
-        "title": "Inclusive Host Count",
-        "description": "If true, include the network and broadcast addresses (useful for CIDR/31 and CIDR/32).",
-        "type": "boolean"
     }
-  }
 }

--- a/src/test/java/io/gravitee/policy/ipfiltering/ExtractIpsTest.java
+++ b/src/test/java/io/gravitee/policy/ipfiltering/ExtractIpsTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
@@ -324,7 +324,7 @@ public class IPFilteringPolicyTest {
             "Your IP (192.168.0.2) or some proxies whereby your request pass through are not allowed to reach this resource.",
             policyResult.message()
         );
-        assertEquals(HttpStatusCode.FORBIDDEN_403, policyResult.httpStatusCode());
+        assertEquals(HttpStatusCode.FORBIDDEN_403, policyResult.statusCode());
         verify(mockPolicychain, never()).doNext(any(Request.class), any(Response.class));
     }
 
@@ -345,7 +345,7 @@ public class IPFilteringPolicyTest {
             "Your IP (localhost, 10.0.0.1, unknown) or some proxies whereby your request pass through are not allowed to reach this resource.",
             policyResult.message()
         );
-        assertEquals(HttpStatusCode.FORBIDDEN_403, policyResult.httpStatusCode());
+        assertEquals(HttpStatusCode.FORBIDDEN_403, policyResult.statusCode());
     }
 
     @Test

--- a/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
@@ -16,8 +16,13 @@
 package io.gravitee.policy.ipfiltering;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.el.TemplateContext;
@@ -30,7 +35,7 @@ import io.gravitee.gateway.api.http.HttpHeaders;
 import io.gravitee.node.api.configuration.Configuration;
 import io.gravitee.policy.api.PolicyChain;
 import io.gravitee.policy.api.PolicyResult;
-import io.reactivex.Maybe;
+import io.reactivex.rxjava3.core.Maybe;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -38,14 +43,12 @@ import io.vertx.core.dns.DnsClient;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @SuppressWarnings("removal")

--- a/src/test/java/io/gravitee/policy/ipfiltering/IsFilteredTest.java
+++ b/src/test/java/io/gravitee/policy/ipfiltering/IsFilteredTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/io/gravitee/policy/ipfiltering/LazyDnsClientTest.java
+++ b/src/test/java/io/gravitee/policy/ipfiltering/LazyDnsClientTest.java
@@ -1,11 +1,11 @@
-/**
- * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+/*
+ * Copyright © 2015 The Gravitee team (http://gravitee.io)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
**Description**

Bump dependencies.

⚠️ Require Java 17

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.0-bump-dependencies-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/2.0.0-bump-dependencies-SNAPSHOT/gravitee-policy-ipfiltering-2.0.0-bump-dependencies-SNAPSHOT.zip)
  <!-- Version placeholder end -->
