### PR TITLE
fix: IPV6 CIDR ranges do not work in the IP filtering policy

### DIFF
--- a/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
@@ -16,8 +16,15 @@
 package io.gravitee.policy.ipfiltering;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.el.TemplateContext;
@@ -434,5 +441,81 @@ public class IPFilteringPolicyTest {
         policy.onRequest(executionContext, mockPolicychain);
         verify(mockPolicychain, times(1)).failWith(any(PolicyResult.class));
         verify(mockPolicychain, never()).doNext(any(Request.class), any(Response.class));
+    }
+
+    @Test
+    public void isIpInFilterIpRange_ipV4_in_filterIpRange() {
+        IPFilteringPolicy policy = new IPFilteringPolicy(mockConfiguration);
+        String ip = "192.168.0.1";
+        String filterIp = "192.168.0.0/24";
+        boolean res = policy.isIpInFilterIpRange(ip, filterIp);
+        assertTrue(res);
+    }
+
+    @Test
+    public void isIpInFilterIpRange_networkIpV4_in_filterIpRange_isNotInclusiveHostCount() {
+        IPFilteringPolicy policy = new IPFilteringPolicy(mockConfiguration);
+        String ip = "192.168.0.0";
+        String filterIp = "192.168.0.0/24";
+        boolean res = policy.isIpInFilterIpRange(ip, filterIp);
+        assertFalse(res);
+    }
+
+    @Test
+    public void isIpInFilterIpRange_networkIpV4_in_filterIpRange_isInclusiveHostCount() {
+        IPFilteringPolicyConfiguration configuration = new IPFilteringPolicyConfiguration();
+        configuration.setIsInclusiveHostCount(true);
+        IPFilteringPolicy policy = new IPFilteringPolicy(configuration);
+        String ip = "192.168.0.0";
+        String filterIp = "192.168.0.0/24";
+        boolean res = policy.isIpInFilterIpRange(ip, filterIp);
+        assertTrue(res);
+    }
+
+    @Test
+    public void isIpInFilterIpRange_broadcastIpV4_in_filterIpRange_isNotInclusiveHostCount() {
+        IPFilteringPolicy policy = new IPFilteringPolicy(mockConfiguration);
+        String ip = "192.168.0.255";
+        String filterIp = "192.168.0.0/24";
+        boolean res = policy.isIpInFilterIpRange(ip, filterIp);
+        assertFalse(res);
+    }
+
+    @Test
+    public void isIpInFilterIpRange_broadcastIpV4_in_filterIpRange_isInclusiveHostCount() {
+        IPFilteringPolicyConfiguration configuration = new IPFilteringPolicyConfiguration();
+        configuration.setIsInclusiveHostCount(true);
+        IPFilteringPolicy policy = new IPFilteringPolicy(configuration);
+        String ip = "192.168.0.255";
+        String filterIp = "192.168.0.0/24";
+        boolean res = policy.isIpInFilterIpRange(ip, filterIp);
+        assertTrue(res);
+    }
+
+    @Test
+    public void isIpInFilterIpRange_ipV4_not_in_filterIpRange() {
+        IPFilteringPolicy policy = new IPFilteringPolicy(mockConfiguration);
+        String ip = "192.168.0.1";
+        String filterIp = "192.169.0.0/24";
+        boolean res = policy.isIpInFilterIpRange(ip, filterIp);
+        assertFalse(res);
+    }
+
+    @Test
+    public void isIpInFilterIpRange_ipV6_in_filterIpRange() {
+        IPFilteringPolicy policy = new IPFilteringPolicy(mockConfiguration);
+        String ip = "2001:db8::1";
+        String filterIp = "2001:db8::/64";
+        boolean res = policy.isIpInFilterIpRange(ip, filterIp);
+        assertTrue(res);
+    }
+
+    @Test
+    public void isIpInFilterIpRange_ipV6_not_in_filterIpRange() {
+        IPFilteringPolicy policy = new IPFilteringPolicy(mockConfiguration);
+        String ip = "2001:db8::1";
+        String filterIp = "2001:db9::/64";
+        boolean res = policy.isIpInFilterIpRange(ip, filterIp);
+        assertFalse(res);
     }
 }


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/APIM-10185
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `1.19.2-apim-10185-1-19-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/1.19.2-apim-10185-1-19-SNAPSHOT/gravitee-policy-ipfiltering-1.19.2-apim-10185-1-19-SNAPSHOT.zip)
  <!-- Version placeholder end -->
