### PR TITLE
Multipe bypass in IP Filtering policy with hostname specified - APIM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>


### PR DESCRIPTION
https://gravitee.atlassian.net/browse/PEN-29
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.2-pen-29-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/2.0.2-pen-29-SNAPSHOT/gravitee-policy-ipfiltering-2.0.2-pen-29-SNAPSHOT.zip)
  <!-- Version placeholder end -->
