### PR TITLE
fix: correct IP filtering logic for combined IP/hostname whitelists/blacklists

### DIFF
--- a/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
@@ -18,13 +18,7 @@ package io.gravitee.policy.ipfiltering;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.el.TemplateContext;
@@ -47,11 +41,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -325,7 +321,7 @@ public class IPFilteringPolicyTest {
         verify(mockPolicychain, times(1)).failWith(policyResultCaptor.capture());
         PolicyResult policyResult = policyResultCaptor.getValue();
         assertEquals(
-            "Your IP (192.168.0.2) or some proxies whereby your request pass through are not allowed to reach this resource.",
+            "Your IP (localhost, 10.0.0.1, 192.168.0.2, unknown) or some proxies whereby your request pass through are not allowed to reach this resource.",
             policyResult.message()
         );
         assertEquals(HttpStatusCode.FORBIDDEN_403, policyResult.httpStatusCode());
@@ -517,5 +513,63 @@ public class IPFilteringPolicyTest {
         String filterIp = "2001:db9::/64";
         boolean res = policy.isIpInFilterIpRange(ip, filterIp);
         assertFalse(res);
+    }
+
+    @Test
+    public void shouldAllowRequestWhenIpInWhitelistOrHostnameResolvesToWhitelist() throws InterruptedException {
+        when(mockConfiguration.isUseCustomIPAddress()).thenReturn(false);
+        when(mockConfiguration.getWhitelistIps()).thenReturn(List.of("93.184.216.34", "example.com"));
+        when(mockConfiguration.getBlacklistIps()).thenReturn(List.of());
+        when(mockRequest.remoteAddress()).thenReturn("93.184.216.34");
+        when(mockConfiguration.getLookupIpVersion()).thenReturn(LookupIpVersion.ALL);
+
+        IPFilteringPolicy policy = new IPFilteringPolicy(mockConfiguration);
+        CountDownLatch latch = new CountDownLatch(1);
+        doAnswer(invocation -> {
+                latch.countDown();
+                return null;
+            })
+            .when(mockPolicychain)
+            .doNext(any(), any());
+
+        try (MockedStatic<LazyDnsClient> lazyDnsMock = mockStatic(LazyDnsClient.class)) {
+            lazyDnsMock
+                .when(() -> LazyDnsClient.lookup(any(), any(), eq("example.com"), any()))
+                .thenAnswer(invocation -> {
+                    var handler = invocation.getArgument(3, io.vertx.core.Handler.class);
+                    handler.handle(Future.succeededFuture(List.of("93.184.216.34")));
+                    return null;
+                });
+            policy.onRequest(executionContext, mockPolicychain);
+        }
+
+        verify(mockPolicychain, never()).failWith(any());
+        verify(mockPolicychain, times(1)).doNext(any(), any());
+    }
+
+    @Test
+    public void shouldFailRequestWhenIpOrHostnameMatchesBlacklist() {
+        when(mockConfiguration.isUseCustomIPAddress()).thenReturn(false);
+        when(mockConfiguration.getWhitelistIps()).thenReturn(List.of());
+        when(mockConfiguration.getBlacklistIps()).thenReturn(List.of("192.168.0.5", "badhost.com"));
+        when(mockRequest.remoteAddress()).thenReturn("93.184.216.34"); // IP that will match the hostname
+        when(mockConfiguration.getLookupIpVersion()).thenReturn(LookupIpVersion.ALL);
+
+        IPFilteringPolicy policy = new IPFilteringPolicy(mockConfiguration);
+
+        try (MockedStatic<LazyDnsClient> lazyDnsMock = mockStatic(LazyDnsClient.class)) {
+            lazyDnsMock
+                .when(() -> LazyDnsClient.lookup(any(), any(), eq("badhost.com"), any()))
+                .thenAnswer(invocation -> {
+                    var handler = invocation.getArgument(3, io.vertx.core.Handler.class);
+                    handler.handle(Future.succeededFuture(List.of("93.184.216.34")));
+                    return null;
+                });
+
+            policy.onRequest(executionContext, mockPolicychain);
+        }
+
+        verify(mockPolicychain, times(1)).failWith(any());
+        verify(mockPolicychain, never()).doNext(any(), any());
     }
 }


### PR DESCRIPTION

**Issue**

https://gravitee.atlassian.net/browse/APIM-11317
**Description**

This commit resolves a regression in the IP filtering policy where mixing hostnames (like gravitee.io) and literal IP addresses in the whitelist section caused all subsequent requests to fail with a 403 error.

Problem: When the policy processed the list of whitelisted entries, the presence of a hostname caused the internal filtering logic to incorrectly handle the subsequent IP address entries, leading to a match failure even for valid IPs.

Solution: Updated the policy evaluation to correctly iterate through and match both resolved host IPs and literal IP addresses, ensuring that a request is successfully allowed if its source IP (from the True-Client-IP header) matches any entry in the combined whitelist.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
