### PR TITLE
feat: enable for native api entrypoint connect phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.1.0-alpha.1](https://github.com/gravitee-io/gravitee-policy-ipfiltering/compare/2.0.3...2.1.0-alpha.1) (2025-11-07)
+
+
+### Features
+
+* enable for LLM & MCP Proxy API ([7b228a1](https://github.com/gravitee-io/gravitee-policy-ipfiltering/commit/7b228a110da95073eb9ce733faf37c4871e6a05f))
+
 ## [2.0.3](https://github.com/gravitee-io/gravitee-policy-ipfiltering/compare/2.0.2...2.0.3) (2025-10-20)
 
 

--- a/README.adoc
+++ b/README.adoc
@@ -10,12 +10,15 @@ endif::[]
 == Phase
 
 |===
-|onRequest |onResponse
+|onRequest |onResponse |onEntrypointConnect (Native Kafka)
 
 |X
 |
+|X
 
 |===
+
+NOTE: For Native Kafka APIs, this policy executes during the `ENTRYPOINT_CONNECT` phase, which occurs at the TCP connection level before authentication.
 
 == Description
 
@@ -30,6 +33,18 @@ The blacklist takes precedence, so if an IP address is included in both lists, t
 You can specify a host to be resolved and checked against the remote IP.
 
 NOTE: When using domain name, the Gateway is performing DNS Lookup with the DNS server configured on the host by default. If you want to use a specific DNS server, you can configure it at the policy level. See <<_gateway>> for more information.
+
+=== Native Kafka API Support
+
+For Native Kafka APIs, this policy executes during the `ENTRYPOINT_CONNECT` phase at the TCP connection level. This enables early rejection of unauthorized connections before authentication and protocol handshake.
+
+**Limitations for Native Kafka:**
+
+* **DNS lookups (hostnames) are not supported** - Only IP addresses and CIDR ranges are evaluated for performance reasons.
+* **`matchAllFromXForwardedFor` is not applicable** - Native Kafka uses raw TCP connections without HTTP headers.
+* **Custom IP addresses with comma-separated values** - Only the first IP is used, as each TCP connection has a single source address.
+
+If hostnames are configured in whitelist/blacklist for a Native Kafka API, they will be logged as warnings and ignored during the `ENTRYPOINT_CONNECT` phase.
 
 == Compatibility with APIM
 
@@ -50,27 +65,39 @@ At the policy level, you can configure the following options:
 
 |matchAllFromXForwardedFor
 |No
-|If set to `true`, the `X-Forwarded-For` header is parsed to extract all IP addresses and check them against the whitelist or blacklist.
+|If set to `true`, the `X-Forwarded-For` header is parsed to extract all IP addresses and check them against the whitelist or blacklist. *Not applicable to Native Kafka APIs.*
 |boolean
 |`false`
 
 |whitelistIps
 |No
-|A list of allowed IPs with or without CIDR notation (host is allowed)
+|A list of allowed IPs with or without CIDR notation. Hostnames are supported for HTTP/MESSAGE APIs but not Native Kafka APIs.
 |string list
 |`empty`
 
 |blacklistIps
 |No
-|A list of denied IPs with or without CIDR notation (host is allowed)
+|A list of denied IPs with or without CIDR notation. Hostnames are supported for HTTP/MESSAGE APIs but not Native Kafka APIs.
 |string list
 |`empty`
 
 |lookupIpVersion
 |No
-|IP version to use to lookup host name. If you're not sure your DNS server can handle multi-question requests (both V4 and V6) specify a version.
+|IP version to use to lookup host name. If you're not sure your DNS server can handle multi-question requests (both V4 and V6) specify a version. *Only applicable to HTTP/MESSAGE APIs (not Native Kafka).*
 |enum [`IPV4`, `IPV6`, `ALL`]
 |`ALL`
+
+|useCustomIPAddress
+|No
+|Override the remote address with a custom value extracted from EL expressions. Useful for extracting IPs from headers or context attributes.
+|boolean
+|`false`
+
+|customIPAddress
+|No
+|Custom IP address to use instead of the remote address. Supports EL expressions (e.g., `{#request.headers['X-Forwarded-For']}`). For Native Kafka, only the first IP from comma-separated values is used.
+|string
+|`empty`
 
 
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
     <properties>
         <gravitee-bom.version>8.3.39</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.13.0</gravitee-gateway-api.version>
+        <gravitee-gateway-api.version>4.3.0-APIM-12432-interrupt-exception-entrypoint-connect-SNAPSHOT</gravitee-gateway-api.version>
         <gravitee-node-api.version>6.8.3</gravitee-node-api.version>
 
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <groupId>io.gravitee.policy</groupId>
     <artifactId>gravitee-policy-ipfiltering</artifactId>
-    <version>2.0.3</version>
+    <version>2.1.0-alpha.1</version>
 
     <name>Gravitee.io APIM - Policy - IP Filtering</name>
     <description>

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -11,3 +11,4 @@ http_proxy=REQUEST
 http_message=REQUEST
 mcp_proxy=REQUEST
 llm_proxy=REQUEST
+native_kafka=ENTRYPOINT_CONNECT

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -6,5 +6,8 @@ class=io.gravitee.policy.ipfiltering.IPFilteringPolicy
 type=policy
 category=security
 icon=ip-filtering.svg
-proxy=REQUEST
-message=REQUEST
+
+http_proxy=REQUEST
+http_message=REQUEST
+mcp_proxy=REQUEST
+llm_proxy=REQUEST

--- a/src/main/resources/schemas/schema-form.json
+++ b/src/main/resources/schemas/schema-form.json
@@ -5,7 +5,9 @@
     "properties": {
         "matchAllFromXForwardedFor": {
             "title": "Use X-Forwarded-For header",
+            "description": "Extract and check all IPs from X-Forwarded-For header. Not applicable to Native Kafka APIs (no HTTP headers).",
             "type": "boolean",
+            "default": false,
             "x-schema-form": {
                 "hidden": [
                     {
@@ -25,11 +27,12 @@
         },
         "useCustomIPAddress": {
             "title": "Use custom IP address (support EL)",
-            "type": "boolean"
+            "type": "boolean",
+            "default": false
         },
         "customIPAddress": {
             "title": "Custom IP Address (support comma separated list)",
-            "description": "Support EL (ex: {#request.headers['X-Forwarded-For']})",
+            "description": "Support EL (ex: {#request.headers['X-Forwarded-For']}). For Native Kafka, only the first IP from comma-separated values is used.",
             "type": "string",
             "x-schema-form": {
                 "expression-language": true,
@@ -51,7 +54,7 @@
         },
         "whitelistIps": {
             "title": "IPs Whitelist (CIDR and hosts allowed)",
-            "description": "List of IPs to allow in the request. Each entry may be a comma-separated list.",
+            "description": "List of IPs to allow in the request. Each entry may be a comma-separated list. Hostnames are for HTTP/MESSAGE only, and not Native Kafka.",
             "type": "array",
             "items": {
                 "title": "IP / CIDR / Host",
@@ -61,7 +64,7 @@
         },
         "blacklistIps": {
             "title": "IPs Blacklist (CIDR and hosts allowed)",
-            "description": "List of IPs to disallow in the request. Each entry may be a comma-separated list.",
+            "description": "List of IPs to disallow in the request. Each entry may be a comma-separated list. Hostnames are for HTTP/MESSAGE only, and not Native Kafka.",
             "type": "array",
             "items": {
                 "title": "IP / CIDR / Host",
@@ -71,7 +74,7 @@
         },
         "lookupIpVersion": {
             "title": "Lookup IP version to use (default is ALL)",
-            "description": "If you're not sure your DNS server can handle multi-question requests (both V4 and V6) specify a version",
+            "description": "If you're not sure your DNS server can handle multi-question requests (both V4 and V6) specify a version. Only applicable to HTTP/MESSAGE APIs (not Native Kafka).",
             "type": "string",
             "enum": ["IPV4", "IPV6", "ALL"],
             "default": "ALL"


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-12433

**Description**

Enable policy for native api's entrypoint connect phase.

**Additional context (Assumptions/Limitations)**

- DNS lookups (hostnames) are not supported - Due to performance reasons as DNS resolution would add 50-500ms latency per connection.
- matchAllFromXForwardedFor is not applicable - Native Kafka uses raw TCP connections without HTTP headers.
- Custom IP addresses with comma-separated values - Only the first IP is used, as each TCP connection has a single source address.
- If hostnames are configured in whitelist/blacklist for a Native Kafka API, they will be logged as warnings and ignored during the ENTRYPOINT_CONNECT phase.
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.1.0-APIM-12433-enable-for-native-api-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/2.1.0-APIM-12433-enable-for-native-api-SNAPSHOT/gravitee-policy-ipfiltering-2.1.0-APIM-12433-enable-for-native-api-SNAPSHOT.zip)
  <!-- Version placeholder end -->
