### PR TITLE
feat: vertx5 upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 setup: true
 
 orbs:
-    gravitee: gravitee-io/gravitee@4.14.2
+    gravitee: gravitee-io/gravitee@6.0.0
 
 # our single workflow, that triggers the setup job defined above, filters on tag and branches are needed otherwise
 # some workflow and job will not be triggered for tags (default CircleCI behavior)

--- a/pom.xml
+++ b/pom.xml
@@ -33,16 +33,16 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>22.5.1</version>
+        <version>25.0.0-alpha.1</version>
     </parent>
 
     <properties>
-        <gravitee-bom.version>8.3.39</gravitee-bom.version>
-        <gravitee-gateway-api.version>3.13.0</gravitee-gateway-api.version>
+        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
+        <gravitee-gateway-api.version>5.0.0-beta.3</gravitee-gateway-api.version>
         <gravitee-node-api.version>6.8.3</gravitee-node-api.version>
 
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>4.7.0</gravitee-common.version>
+        <gravitee-common.version>5.0.0-beta.1</gravitee-common.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,12 @@
     </parent>
 
     <properties>
-        <gravitee-bom.version>9.0.0-beta.2</gravitee-bom.version>
-        <gravitee-gateway-api.version>5.0.0-beta.3</gravitee-gateway-api.version>
-        <gravitee-node-api.version>6.8.3</gravitee-node-api.version>
+        <gravitee-bom.version>9.0.0-alpha.2</gravitee-bom.version>
+        <gravitee-gateway-api.version>6.0.0-alpha.1</gravitee-gateway-api.version>
+        <gravitee-node-api.version>9.0.0-alpha.1</gravitee-node-api.version>
 
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
-        <gravitee-common.version>5.0.0-beta.1</gravitee-common.version>
+        <gravitee-common.version>5.0.0-alpha.1</gravitee-common.version>
 
         <json-schema-generator-maven-plugin.version>1.3.0</json-schema-generator-maven-plugin.version>
         <json-schema-generator-maven-plugin.outputDirectory>${project.build.directory}/schemas</json-schema-generator-maven-plugin.outputDirectory>

--- a/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/IPFilteringPolicy.java
@@ -27,7 +27,6 @@ import io.gravitee.policy.api.PolicyResult;
 import io.gravitee.policy.api.annotations.OnRequest;
 import io.netty.handler.ipfilter.IpFilterRuleType;
 import io.netty.handler.ipfilter.IpSubnetFilterRule;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import java.net.InetAddress;
@@ -65,7 +64,7 @@ public class IPFilteringPolicy {
     @OnRequest
     public void onRequest(ExecutionContext executionContext, PolicyChain policyChain) {
         final List<String> ips = extractIps(executionContext);
-        final List<Future> futures = new ArrayList<>();
+        final List<Future<?>> futures = new ArrayList<>();
 
         var blackList = computeList(executionContext, configuration.getBlacklistIps());
         var whiteList = computeList(executionContext, configuration.getWhitelistIps());
@@ -74,7 +73,10 @@ public class IPFilteringPolicy {
             final List<String> filteredIps = new ArrayList<>();
             final List<String> filteredHosts = new ArrayList<>();
             processFilteredLists(blackList, filteredIps, filteredHosts);
-            Optional<String> matchingIp = ips.stream().filter(ip -> isFiltered(ip, filteredIps)).findFirst();
+            Optional<String> matchingIp = ips
+                .stream()
+                .filter(ip -> isFiltered(ip, filteredIps))
+                .findFirst();
             if (matchingIp.isPresent()) {
                 fail(policyChain, matchingIp.get());
                 return;
@@ -106,8 +108,7 @@ public class IPFilteringPolicy {
         if (futures.isEmpty()) {
             policyChain.doNext(executionContext.request(), executionContext.response());
         } else {
-            CompositeFuture
-                .all(futures)
+            Future.all(futures)
                 .onSuccess(__ -> policyChain.doNext(executionContext.request(), executionContext.response()))
                 .onFailure(__ -> fail(policyChain, executionContext.request().remoteAddress()));
         }
@@ -121,32 +122,27 @@ public class IPFilteringPolicy {
      */
     private void blacklistFilteredHostsProcess(
         List<String> filteredHosts,
-        List<Future> futures,
+        List<Future<?>> futures,
         ExecutionContext executionContext,
         List<String> ips
     ) {
         filteredHosts.forEach(host -> {
             final Promise<Void> promise = Promise.promise();
             futures.add(promise.future());
-            LazyDnsClient.lookup(
-                executionContext,
-                configuration.getLookupIpVersion(),
-                host,
-                event -> {
-                    if (event.succeeded()) {
-                        List<String> resolvedIps = event.result();
-                        boolean matchFound = ips.stream().anyMatch(resolvedIps::contains);
-                        if (matchFound) {
-                            promise.fail("");
-                        } else {
-                            promise.complete();
-                        }
+            LazyDnsClient.lookup(executionContext, configuration.getLookupIpVersion(), host, event -> {
+                if (event.succeeded()) {
+                    List<String> resolvedIps = event.result();
+                    boolean matchFound = ips.stream().anyMatch(resolvedIps::contains);
+                    if (matchFound) {
+                        promise.fail("");
                     } else {
-                        LOGGER.error("Cannot resolve host: '{}'", host, event.cause());
-                        promise.fail("Cannot resolve host: '" + host + "'");
+                        promise.complete();
                     }
+                } else {
+                    LOGGER.error("Cannot resolve host: '{}'", host, event.cause());
+                    promise.fail("Cannot resolve host: '" + host + "'");
                 }
-            );
+            });
         });
     }
 
@@ -158,32 +154,27 @@ public class IPFilteringPolicy {
      */
     private void whitelistFilteredHostsProcess(
         List<String> filteredHosts,
-        List<Future> futures,
+        List<Future<?>> futures,
         ExecutionContext executionContext,
         List<String> ips
     ) {
         filteredHosts.forEach(host -> {
             final Promise<Void> promise = Promise.promise();
             futures.add(promise.future());
-            LazyDnsClient.lookup(
-                executionContext,
-                configuration.getLookupIpVersion(),
-                host,
-                event -> {
-                    if (event.succeeded()) {
-                        List<String> resolvedIps = event.result();
-                        boolean matchFound = ips.stream().anyMatch(resolvedIps::contains);
-                        if (!matchFound) {
-                            promise.fail("");
-                        } else {
-                            promise.complete();
-                        }
+            LazyDnsClient.lookup(executionContext, configuration.getLookupIpVersion(), host, event -> {
+                if (event.succeeded()) {
+                    List<String> resolvedIps = event.result();
+                    boolean matchFound = ips.stream().anyMatch(resolvedIps::contains);
+                    if (!matchFound) {
+                        promise.fail("");
                     } else {
-                        LOGGER.error("Cannot resolve host: '{}'", host, event.cause());
-                        promise.fail("Cannot resolve host: '" + host + "'");
+                        promise.complete();
                     }
+                } else {
+                    LOGGER.error("Cannot resolve host: '{}'", host, event.cause());
+                    promise.fail("Cannot resolve host: '" + host + "'");
                 }
-            );
+            });
         });
     }
 

--- a/src/main/java/io/gravitee/policy/ipfiltering/LazyDnsClient.java
+++ b/src/main/java/io/gravitee/policy/ipfiltering/LazyDnsClient.java
@@ -65,8 +65,7 @@ public class LazyDnsClient {
             Future<List<String>> ipv4Future = client.resolveA(host);
             Future<List<String>> ipv6Future = client.resolveAAAA(host);
 
-            Future
-                .all(ipv4Future, ipv6Future)
+            Future.all(ipv4Future, ipv6Future)
                 .map(cf -> {
                     List<String> all = new ArrayList<>();
                     all.addAll(cf.resultAt(0)); // ipv4Future result

--- a/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
+++ b/src/test/java/io/gravitee/policy/ipfiltering/IPFilteringPolicyTest.java
@@ -456,18 +456,16 @@ public class IPFilteringPolicyTest {
         DnsClient mockDnsClient = mock(DnsClient.class);
         when(executionContext.getComponent(Vertx.class)).thenReturn(mockVertx);
         when(mockVertx.createDnsClient(any())).thenReturn(mockDnsClient);
-        when(mockDnsClient.resolveA("example.com"))
-            .thenAnswer(invocation -> {
-                Promise<Void> promise = Promise.promise();
-                promise.fail(new Throwable("DNS resolution failed"));
-                return promise.future();
-            });
-        when(mockDnsClient.resolveAAAA("example.com"))
-            .thenAnswer(invocation -> {
-                Promise<Void> promise = Promise.promise();
-                promise.fail(new Throwable("DNS resolution failed"));
-                return promise.future();
-            });
+        when(mockDnsClient.resolveA("example.com")).thenAnswer(invocation -> {
+            Promise<Void> promise = Promise.promise();
+            promise.fail(new Throwable("DNS resolution failed"));
+            return promise.future();
+        });
+        when(mockDnsClient.resolveAAAA("example.com")).thenAnswer(invocation -> {
+            Promise<Void> promise = Promise.promise();
+            promise.fail(new Throwable("DNS resolution failed"));
+            return promise.future();
+        });
         IPFilteringPolicy policy = new IPFilteringPolicy(mockConfiguration);
 
         policy.onRequest(executionContext, mockPolicychain);

--- a/src/test/java/io/gravitee/policy/ipfiltering/LazyDnsClientTest.java
+++ b/src/test/java/io/gravitee/policy/ipfiltering/LazyDnsClientTest.java
@@ -74,15 +74,10 @@ public class LazyDnsClientTest {
         List<String> ipv4 = List.of("192.168.0.1");
         when(dnsClient.resolveA(eq("example.com"))).thenReturn(Future.succeededFuture(ipv4));
 
-        LazyDnsClient.lookup(
-            executionContext,
-            LookupIpVersion.IPV4,
-            "example.com",
-            result -> {
-                assertTrue(result.succeeded());
-                assertEquals(ipv4, result.result());
-            }
-        );
+        LazyDnsClient.lookup(executionContext, LookupIpVersion.IPV4, "example.com", result -> {
+            assertTrue(result.succeeded());
+            assertEquals(ipv4, result.result());
+        });
 
         verify(dnsClient).resolveA("example.com");
     }
@@ -92,15 +87,10 @@ public class LazyDnsClientTest {
         List<String> ipv6 = List.of("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
         when(dnsClient.resolveAAAA(eq("example.com"))).thenReturn(Future.succeededFuture(ipv6));
 
-        LazyDnsClient.lookup(
-            executionContext,
-            LookupIpVersion.IPV6,
-            "example.com",
-            result -> {
-                assertTrue(result.succeeded());
-                assertEquals(ipv6, result.result());
-            }
-        );
+        LazyDnsClient.lookup(executionContext, LookupIpVersion.IPV6, "example.com", result -> {
+            assertTrue(result.succeeded());
+            assertEquals(ipv6, result.result());
+        });
 
         verify(dnsClient).resolveAAAA("example.com");
     }
@@ -112,15 +102,10 @@ public class LazyDnsClientTest {
         when(dnsClient.resolveA(eq("example.com"))).thenReturn(Future.succeededFuture(ipv4));
         when(dnsClient.resolveAAAA(eq("example.com"))).thenReturn(Future.succeededFuture(ipv6));
 
-        LazyDnsClient.lookup(
-            executionContext,
-            LookupIpVersion.ALL,
-            "example.com",
-            result -> {
-                assertTrue(result.succeeded());
-                assertThat(result.result()).containsExactlyInAnyOrder(ipv4.get(0), ipv6.get(0));
-            }
-        );
+        LazyDnsClient.lookup(executionContext, LookupIpVersion.ALL, "example.com", result -> {
+            assertTrue(result.succeeded());
+            assertThat(result.result()).containsExactlyInAnyOrder(ipv4.get(0), ipv6.get(0));
+        });
 
         verify(dnsClient).resolveA("example.com");
         verify(dnsClient).resolveAAAA("example.com");
@@ -131,13 +116,8 @@ public class LazyDnsClientTest {
         when(dnsClient.resolveA(eq("example.com"))).thenReturn(Future.failedFuture(new RuntimeException("DNS fail")));
         when(dnsClient.resolveAAAA(eq("example.com"))).thenReturn(Future.failedFuture(new RuntimeException("IPv6 also fail")));
 
-        LazyDnsClient.lookup(
-            executionContext,
-            LookupIpVersion.ALL,
-            "example.com",
-            result -> {
-                assertFalse(result.succeeded());
-            }
-        );
+        LazyDnsClient.lookup(executionContext, LookupIpVersion.ALL, "example.com", result -> {
+            assertFalse(result.succeeded());
+        });
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: Vertx5, JDK 25

**Issue**

https://gravitee.atlassian.net/browse/AM-6611

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-AM-6611-vertx-5-migration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/3.0.0-AM-6611-vertx-5-migration-SNAPSHOT/gravitee-policy-ipfiltering-3.0.0-AM-6611-vertx-5-migration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `3.0.0-AM-6611-vertx-5-migration-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/3.0.0-AM-6611-vertx-5-migration-SNAPSHOT/gravitee-policy-ipfiltering-3.0.0-AM-6611-vertx-5-migration-SNAPSHOT.zip)
  <!-- Version placeholder end -->
