### PR TITLE
fix(doc): add note for X-Forwarded-For in readme.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,9 @@ You can allow or deny a specific IP address or range of IP addresses with https:
 Whitelist mode excludes all IP addresses except the addresses included in the whitelist.
 Blacklist mode allows all IP addresses except the addresses included in the blacklist.
 
+NOTE: The `X-Forwarded-For` header verification is only applicable to self-hosted gateways.
+On SaaS-based gateways (Gravitee Cloud), the `X-Forwarded-For` header isn't available for IP filtering because the SaaS infrastructure manages traffic routing differently.
+
 The blacklist takes precedence, so if an IP address is included in both lists, the policy rejects the request.
 
 You can specify a host to be resolved and checked against the remote IP.


### PR DESCRIPTION
**Issue**

https://gravitee.atlassian.net/browse/APIM-13213

**Description**

Added a note in overview: `The X-Forwarded-For header verification is only applicable to self-hosted gateways. On SaaS-based gateways (Gravitee Cloud), the X-Forwarded-For header isn't available for IP filtering because the SaaS infrastructure manages traffic routing differently.`

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->
<!-- Version placeholder -->

---
**Gravitee.io Automatic Deployment**

🚀 A prerelease version of this package has been published on Gravitee's private artifactory, you can:
 - use it directly by updating your project with version: `2.0.4-APIM-13213-Update-documentation-2-0-3-x-SNAPSHOT`
 - download it from Artifactory [here](https://odbxikk7vo-artifactory.services.clever-cloud.com/gravitee-snapshots/io/gravitee/policy/gravitee-policy-ipfiltering/2.0.4-APIM-13213-Update-documentation-2-0-3-x-SNAPSHOT/gravitee-policy-ipfiltering-2.0.4-APIM-13213-Update-documentation-2-0-3-x-SNAPSHOT.zip)
  <!-- Version placeholder end -->
